### PR TITLE
feat: improve skill scores for fe-tools

### DIFF
--- a/utils/.cursor/skills/add-tests/SKILL.md
+++ b/utils/.cursor/skills/add-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-tests
-description: Add or update Jest unit tests for fe-tools utilities. Use when new functions are added, existing behavior changes, or the user asks to补测试/add tests across utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Add or update Jest unit tests for fe-tools utilities. Writes test cases, verifies coverage for common behavior, edge cases, and error inputs. Use when new functions are added, existing behavior changes, or the user asks to add tests across utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Add Tests
 
@@ -13,11 +13,22 @@ description: Add or update Jest unit tests for fe-tools utilities. Use when new 
    - AI/ML helpers -> `packages/ai-utils`
 2. Find or create a test file in `packages/<pkg>/__tests__/`.
 3. Follow the naming pattern:
-   - `describe('functionName', () => { it('should ...') })`
+   ```ts
+   describe('isValidEmail', () => {
+     it('should return true for valid emails', () => {
+       expect(isValidEmail('user@example.com')).toBe(true);
+     });
+     it('should return false for invalid formats', () => {
+       expect(isValidEmail('not-an-email')).toBe(false);
+     });
+     it('should handle empty string', () => {
+       expect(isValidEmail('')).toBe(false);
+     });
+   });
+   ```
 4. Cover at least:
    - Common expected behavior
    - Edge cases / boundary values
    - Error or invalid input behavior (if applicable)
 5. Use deterministic inputs and avoid external I/O unless required.
-6. Suggest running focused tests:
-   - `TEST_API=<package> npm run test`
+6. Run tests and verify they pass before committing: `TEST_API=<package> npm run test`.

--- a/utils/.cursor/skills/add-utils-function/SKILL.md
+++ b/utils/.cursor/skills/add-utils-function/SKILL.md
@@ -14,7 +14,22 @@ description: Add or modify utility functions in fe-tools. Use when the user asks
 2. Search existing modules to avoid duplication (`rg <keyword> packages`).
 3. If an existing exported function already satisfies the request or differs only by naming/minor boundary behavior, do not create a new function. Reuse the existing function and respond with the current API name, file location, and any relevant behavior notes instead of adding duplicate functionality.
 4. Only when no suitable existing function exists, choose the most appropriate module file (e.g., `array.ts`, `validators.ts`) or create a new focused file. If creating a new file, use the `create-module-file` skill.
-5. Implement the function with explicit types and no `any`.
+5. Implement the function with explicit types and no `any`. Example:
+   ```ts
+   /**
+    * 将字符串首字母大写
+    * Capitalize the first letter of a string.
+    * @param str - 输入字符串 / input string
+    * @returns 首字母大写的字符串 / string with first letter capitalized
+    * @example
+    * capitalize('hello'); // 'Hello'
+    * @example
+    * capitalize(''); // ''
+    */
+   export function capitalize(str: string): string {
+     return str.charAt(0).toUpperCase() + str.slice(1);
+   }
+   ```
 6. Add bilingual JSDoc (Chinese + English), parameter/return docs, and at least two examples. Use the `bilingual-jsdoc` skill if needed.
 7. Export the function from the package `src/index.ts`. Use the `update-index-exports` skill if needed.
 8. Add unit tests in the package `__tests__` directory. Use the `add-tests` skill if needed.

--- a/utils/.cursor/skills/bilingual-jsdoc/SKILL.md
+++ b/utils/.cursor/skills/bilingual-jsdoc/SKILL.md
@@ -1,15 +1,28 @@
 ---
 name: bilingual-jsdoc
-description: Write or update bilingual (Chinese + English) JSDoc for exported functions in fe-tools. Use when the user asks for documentation updates, JSDoc fixes, or when adding/modifying utilities in utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Write or update bilingual (Chinese + English) JSDoc for exported functions in fe-tools. Use when the user asks for documentation updates, JSDoc fixes, or when adding/modifying utilities in utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Bilingual JSDoc
 
 ## Workflow
 1. Confirm which package the function belongs to (utils/web-utils/node-utils/canvas-utils/ai-utils) and open the target module file.
 2. Write JSDoc in the required format:
-   - Chinese description, then English description
-   - `@param` lines with Chinese and English descriptions
+   ```ts
+   /**
+    * 深拷贝对象或数组
+    * Deep clone an object or array.
+    * @param source - 要拷贝的源对象 / source object to clone
+    * @returns 深拷贝后的新对象 / a new deep-cloned object
+    * @example
+    * deepClone({ a: 1, b: { c: 2 } }); // { a: 1, b: { c: 2 } }
+    * @example
+    * deepClone([]); // []
+    */
+   ```
+   Rules:
+   - Chinese description first, then English description
+   - `@param` lines with Chinese and English descriptions separated by `/`
    - `@returns` line with return description
-   - At least two `@example` blocks (common case + edge case, add a third when helpful)
+   - At least two `@example` blocks (common case + edge case)
 3. Ensure types in JSDoc match the TypeScript signature.
-4. Keep wording concise and consistent with existing style.
+4. Verify types compile: `npx tsc --noEmit --project packages/<pkg>/tsconfig.json`.

--- a/utils/.cursor/skills/build-packages/SKILL.md
+++ b/utils/.cursor/skills/build-packages/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: build-packages
-description: Build the fe-tools monorepo packages. Use when the user asks to构建/build/compile, or to verify TypeScript compilation.
+description: "Build the fe-tools monorepo packages. Runs TypeScript compilation across all packages and resolves build errors. Use when the user asks to build, compile, verify TypeScript compilation, or check for type errors."
 ---
 # Build Packages
 
 ## Workflow
 1. Run the standard build command: `npm run build`.
-2. If build fails, identify the first error, summarize the cause, and propose minimal fixes.
+2. If build fails, identify the first error, summarize the cause, and propose minimal fixes. Common issues:
+   - Missing export: add the missing `export` statement in `src/index.ts`
+   - Type mismatch: align the function signature with its JSDoc or callers
+   - Import not found: check the module path and package name spelling
 3. Re-run the build after applying fixes.
+4. Verify build completes with exit code 0 and no error output before considering the task complete.

--- a/utils/.cursor/skills/verify-docs-tests/SKILL.md
+++ b/utils/.cursor/skills/verify-docs-tests/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: verify-docs-tests
-description: Verify documentation and tests in fe-tools. Use when the user asks to检查文档和测试, verify docs/tests, or ensure exports and docs are aligned across utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Verify documentation and tests in fe-tools. Checks that exported functions have corresponding documentation and test coverage, validates JSDoc presence, and identifies missing tests. Use when the user asks to verify docs/tests, or ensure exports and docs are aligned across utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Verify Docs and Tests
 
 ## Workflow
-1. Check that exported APIs in `packages/*/src/index.ts` match documentation expectations (focus on the touched package). Use the `update-index-exports` skill if exports are missing.
-2. Verify new or changed functions have tests in `packages/*/__tests__/` for the same package.
-3. Suggest running tests:
+1. Check that exported APIs in `packages/<pkg>/src/index.ts` match documentation expectations. Compare exports against JSDoc coverage:
+   ```bash
+   # List exports to check for JSDoc
+   grep -n "^export" packages/<pkg>/src/index.ts
+   ```
+   Use the `update-index-exports` skill if exports are missing.
+2. Verify new or changed functions have tests in `packages/<pkg>/__tests__/`. A function is untested if no `describe('functionName')` or `it('...functionName...')` block exists for it.
+3. Run tests and confirm they pass:
    - `npm run test` for all packages
    - `TEST_API=<package> npm run test` for a specific package
 4. If docs output is required, suggest `npm run docs` or use the `sync-docs` skill.

--- a/utils/skills/add-tests/SKILL.md
+++ b/utils/skills/add-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-tests
-description: Add or update Jest unit tests for fe-tools utilities. Use when new functions are added, existing behavior changes, or the user asks to补测试/add tests across utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Add or update Jest unit tests for fe-tools utilities. Writes test cases, verifies coverage for common behavior, edge cases, and error inputs. Use when new functions are added, existing behavior changes, or the user asks to add tests across utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Add Tests
 
@@ -13,11 +13,22 @@ description: Add or update Jest unit tests for fe-tools utilities. Use when new 
    - AI/ML helpers -> `packages/ai-utils`
 2. Find or create a test file in `packages/<pkg>/__tests__/`.
 3. Follow the naming pattern:
-   - `describe('functionName', () => { it('should ...') })`
+   ```ts
+   describe('isValidEmail', () => {
+     it('should return true for valid emails', () => {
+       expect(isValidEmail('user@example.com')).toBe(true);
+     });
+     it('should return false for invalid formats', () => {
+       expect(isValidEmail('not-an-email')).toBe(false);
+     });
+     it('should handle empty string', () => {
+       expect(isValidEmail('')).toBe(false);
+     });
+   });
+   ```
 4. Cover at least:
    - Common expected behavior
    - Edge cases / boundary values
    - Error or invalid input behavior (if applicable)
 5. Use deterministic inputs and avoid external I/O unless required.
-6. Suggest running focused tests:
-   - `TEST_API=<package> npm run test`
+6. Run tests and verify they pass before committing: `TEST_API=<package> npm run test`.

--- a/utils/skills/add-utils-function/SKILL.md
+++ b/utils/skills/add-utils-function/SKILL.md
@@ -14,7 +14,22 @@ description: Add or modify utility functions in fe-tools. Use when the user asks
 2. Search existing modules to avoid duplication (`rg <keyword> packages`).
 3. If an existing exported function already satisfies the request or differs only by naming/minor boundary behavior, do not create a new function. Reuse the existing function and respond with the current API name, file location, and any relevant behavior notes instead of adding duplicate functionality.
 4. Only when no suitable existing function exists, choose the most appropriate module file (e.g., `array.ts`, `validators.ts`) or create a new focused file. If creating a new file, use the `create-module-file` skill.
-5. Implement the function with explicit types and no `any`.
+5. Implement the function with explicit types and no `any`. Example:
+   ```ts
+   /**
+    * 将字符串首字母大写
+    * Capitalize the first letter of a string.
+    * @param str - 输入字符串 / input string
+    * @returns 首字母大写的字符串 / string with first letter capitalized
+    * @example
+    * capitalize('hello'); // 'Hello'
+    * @example
+    * capitalize(''); // ''
+    */
+   export function capitalize(str: string): string {
+     return str.charAt(0).toUpperCase() + str.slice(1);
+   }
+   ```
 6. Add bilingual JSDoc (Chinese + English), parameter/return docs, and at least two examples. Use the `bilingual-jsdoc` skill if needed.
 7. Export the function from the package `src/index.ts`. Use the `update-index-exports` skill if needed.
 8. Add unit tests in the package `__tests__` directory. Use the `add-tests` skill if needed.

--- a/utils/skills/bilingual-jsdoc/SKILL.md
+++ b/utils/skills/bilingual-jsdoc/SKILL.md
@@ -1,15 +1,28 @@
 ---
 name: bilingual-jsdoc
-description: Write or update bilingual (Chinese + English) JSDoc for exported functions in fe-tools. Use when the user asks for documentation updates, JSDoc fixes, or when adding/modifying utilities in utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Write or update bilingual (Chinese + English) JSDoc for exported functions in fe-tools. Use when the user asks for documentation updates, JSDoc fixes, or when adding/modifying utilities in utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Bilingual JSDoc
 
 ## Workflow
 1. Confirm which package the function belongs to (utils/web-utils/node-utils/canvas-utils/ai-utils) and open the target module file.
 2. Write JSDoc in the required format:
-   - Chinese description, then English description
-   - `@param` lines with Chinese and English descriptions
+   ```ts
+   /**
+    * 深拷贝对象或数组
+    * Deep clone an object or array.
+    * @param source - 要拷贝的源对象 / source object to clone
+    * @returns 深拷贝后的新对象 / a new deep-cloned object
+    * @example
+    * deepClone({ a: 1, b: { c: 2 } }); // { a: 1, b: { c: 2 } }
+    * @example
+    * deepClone([]); // []
+    */
+   ```
+   Rules:
+   - Chinese description first, then English description
+   - `@param` lines with Chinese and English descriptions separated by `/`
    - `@returns` line with return description
-   - At least two `@example` blocks (common case + edge case, add a third when helpful)
+   - At least two `@example` blocks (common case + edge case)
 3. Ensure types in JSDoc match the TypeScript signature.
-4. Keep wording concise and consistent with existing style.
+4. Verify types compile: `npx tsc --noEmit --project packages/<pkg>/tsconfig.json`.

--- a/utils/skills/build-packages/SKILL.md
+++ b/utils/skills/build-packages/SKILL.md
@@ -1,10 +1,14 @@
 ---
 name: build-packages
-description: Build the fe-tools monorepo packages. Use when the user asks to构建/build/compile, or to verify TypeScript compilation.
+description: "Build the fe-tools monorepo packages. Runs TypeScript compilation across all packages and resolves build errors. Use when the user asks to build, compile, verify TypeScript compilation, or check for type errors."
 ---
 # Build Packages
 
 ## Workflow
 1. Run the standard build command: `npm run build`.
-2. If build fails, identify the first error, summarize the cause, and propose minimal fixes.
+2. If build fails, identify the first error, summarize the cause, and propose minimal fixes. Common issues:
+   - Missing export: add the missing `export` statement in `src/index.ts`
+   - Type mismatch: align the function signature with its JSDoc or callers
+   - Import not found: check the module path and package name spelling
 3. Re-run the build after applying fixes.
+4. Verify build completes with exit code 0 and no error output before considering the task complete.

--- a/utils/skills/create-module-file/SKILL.md
+++ b/utils/skills/create-module-file/SKILL.md
@@ -1,12 +1,27 @@
 ---
 name: create-module-file
-description: Create a new module file for fe-tools utilities. Use when a new focused file under `packages/<pkg>/src/` is needed (e.g., new validators module).
+description: "Create a new module file for fe-tools utilities. Scaffolds a single-purpose TypeScript module with bilingual JSDoc, exports, and tests. Use when a new focused file under packages/utils/src/, packages/web-utils/src/, packages/node-utils/src/, packages/canvas-utils/src/, or packages/ai-utils/src/ is needed (e.g., new validators module, new string helpers)."
 ---
 # Create Module File
 
 ## Workflow
 1. Confirm the target package (`packages/utils`, `packages/web-utils`, `packages/node-utils`, `packages/canvas-utils`, `packages/ai-utils`).
-2. Create a single-purpose module file under `packages/<pkg>/src/` (one module per file).
-3. Add exported functions with bilingual JSDoc and explicit types.
-4. Update `packages/<pkg>/src/index.ts` to export the new module (use `update-index-exports` if needed).
-5. Add tests in `packages/<pkg>/__tests__/`.
+2. Create a single-purpose module file under `packages/<pkg>/src/` (one module per file). Use a descriptive kebab-case name matching the module's domain (e.g., `validators.ts`, `string-helpers.ts`).
+3. Add exported functions with bilingual JSDoc and explicit types. Example skeleton:
+   ```ts
+   /**
+    * 校验邮箱格式是否合法
+    * Validate whether an email address format is valid.
+    * @param email - 邮箱地址 / email address to validate
+    * @returns 是否合法 / whether the format is valid
+    * @example
+    * isValidEmail('user@example.com'); // true
+    * @example
+    * isValidEmail('not-an-email'); // false
+    */
+   export function isValidEmail(email: string): boolean {
+     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+   }
+   ```
+4. Update `packages/<pkg>/src/index.ts` to export the new module (use `update-index-exports` skill if needed).
+5. Add tests in `packages/<pkg>/__tests__/`. Verify tests pass: `TEST_API=<package> npm run test`.

--- a/utils/skills/fe-tools-template-recommender/SKILL.md
+++ b/utils/skills/fe-tools-template-recommender/SKILL.md
@@ -41,19 +41,20 @@ Verify these paths before recommending:
 7. If no existing template is a strong fit, say so explicitly and recommend the nearest starting point plus the missing pieces to add.
 
 ## Selection Heuristics
-- Prefer modern defaults unless the user asks for legacy compatibility.
-- Frontend:
-  - `vite-react+ts`: default for modern React SPA, admin systems, internal tools, and fast TypeScript startup
-  - `nextjs+ts`: use for SSR, SEO, App Router, content-heavy sites, or routes that benefit from server capabilities
-  - `react`: use only when the user needs a traditional Webpack-based React baseline or compatibility with older setups
-  - `vite-vue3+ts`: default for modern Vue 3 + TS projects
-  - `vue`: use mainly for Vue 2 / legacy Webpack projects
-  - `webpack+ts`: use for framework-free TS apps or when custom bundling control matters more than startup speed
-  - `webpack`: use for plain JS legacy or very simple non-TS bundling needs
-- Backend:
-  - `fastify`: prefer for modern TypeScript APIs, performance, plugin ecosystem, Swagger/OpenAPI, and production-oriented Node services
-  - `koa2`: prefer for lighter custom services when the team wants a simpler middleware mental model
-  - `nestjs`: prefer when the team wants stronger structure, DI, modular architecture, or enterprise-style conventions, but verify its local completeness first because the root template index currently lists it as TODO
+Prefer modern defaults unless the user asks for legacy compatibility.
+
+| Template | Best for |
+|---|---|
+| `vite-react+ts` | Modern React SPA, admin systems, internal tools, fast TS startup |
+| `nextjs+ts` | SSR, SEO, App Router, content-heavy sites, server capabilities |
+| `react` | Traditional Webpack-based React baseline, older setup compatibility |
+| `vite-vue3+ts` | Modern Vue 3 + TS projects |
+| `vue` | Vue 2 / legacy Webpack projects |
+| `webpack+ts` | Framework-free TS apps, custom bundling control |
+| `webpack` | Plain JS legacy, simple non-TS bundling |
+| `fastify` | Modern TS APIs, performance, Swagger/OpenAPI, production services |
+| `koa2` | Lighter custom services, simpler middleware mental model |
+| `nestjs` | DI, modular architecture, enterprise conventions (verify completeness — listed as TODO in root index) |
 
 ## Output Format
 Use this structure:

--- a/utils/skills/select-package/SKILL.md
+++ b/utils/skills/select-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: select-package
-description: Choose the correct fe-tools package for new functionality. Use when the user asks to add a function but the target package is unclear.
+description: "Choose the correct fe-tools package for new functionality. Analyzes function requirements, reviews package responsibilities, and recommends the appropriate target package. Use when the user asks to add a function, create a new feature, or is unsure which package to use, where to add code, or which fe-tools module to target."
 ---
 # Select Package
 
@@ -14,3 +14,12 @@ description: Choose the correct fe-tools package for new functionality. Use when
    - Node image processing workflows -> `packages/node-img-build`
 2. If the request spans multiple runtimes, split into separate functions per package.
 3. State the selection explicitly before coding.
+
+### Examples
+| Requirement | Package |
+|---|---|
+| Format a date string | `packages/utils` |
+| Read a config file from disk | `packages/node-utils` |
+| Detect browser viewport size | `packages/web-utils` |
+| Draw a rounded rectangle on canvas | `packages/canvas-utils` |
+| Tokenize a prompt for an LLM | `packages/ai-utils` |

--- a/utils/skills/sync-docs/SKILL.md
+++ b/utils/skills/sync-docs/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: sync-docs
-description: Regenerate or verify documentation for fe-tools. Use when the user asks to update docs, generate TypeDoc output, or verify documentation alignment.
+description: "Regenerate or verify documentation for fe-tools. Generates API reference from TypeDoc comments, checks for missing documentation, and validates code-doc alignment. Use when the user asks to update docs, generate TypeDoc output, or verify documentation alignment."
 ---
 # Sync Docs
 
 ## Workflow
-1. Ensure exported APIs are correct in `packages/*/src/index.ts`.
+1. Ensure exported APIs are correct in `packages/*/src/index.ts`. Each public function should have a corresponding `export` statement:
+   ```ts
+   export { isValidEmail } from './validators';
+   export { formatDate, parseDate } from './date';
+   ```
 2. Run `npm run docs` to generate TypeDoc output.
-3. If docs errors occur, fix the first reported issue and re-run.
+3. If doc errors occur, fix the first reported issue and re-run. Common issues:
+   - Missing JSDoc on an exported function — add bilingual JSDoc (use `bilingual-jsdoc` skill)
+   - Type reference not found — check import paths
+4. Verify docs generated successfully by confirming the output directory exists and contains updated files.

--- a/utils/skills/sync-skills/SKILL.md
+++ b/utils/skills/sync-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-skills
-description: Sync repository skills to local AI tool skill directories. Use when new skills are added or updated and tool directories need refresh.
+description: "Sync repository skills to local AI tool skill directories. Copies skill files from the source of truth to Claude, Cursor, Codex, Trae, and CodeBuddy directories. Use when new skills are added or updated, tool directories need refresh, or the user asks to copy skills, update agent skills, or install skills locally."
 ---
 # Sync Skills
 
@@ -8,3 +8,4 @@ description: Sync repository skills to local AI tool skill directories. Use when
 1. Treat `skills/` as the preferred source of truth. If it does not exist, fall back to `utils/skills/`.
 2. Run `npm run skills:sync` to copy skills into tool directories.
 3. Avoid editing `.codex/skills`, `.claude/skills`, `.cursor/skills`, `.trae/skills`, or `.codebuddy/skills` directly.
+4. Verify sync by checking that target directories contain the expected skill files.

--- a/utils/skills/update-index-exports/SKILL.md
+++ b/utils/skills/update-index-exports/SKILL.md
@@ -1,12 +1,17 @@
 ---
 name: update-index-exports
-description: Update package exports in fe-tools. Use when a new function/module is added and `src/index.ts` needs to expose it, or when export lists need cleanup.
+description: "Update barrel exports in fe-tools package index files. Adds, removes, or reorders export statements in src/index.ts to expose the public API. Use when a new function or module is added, exports need cleanup, the user mentions barrel file, re-export, expose module, or public API for any fe-tools package."
 ---
 # Update Index Exports
 
 ## Workflow
-1. Identify the package under `packages/` that owns the new module.
+1. Identify the package under `packages/` that owns the new or changed module.
 2. Open `packages/<pkg>/src/index.ts`.
-3. Add or update exports for the new module/function.
+3. Add or update exports for the new module/function. Use the existing style — typically:
+   ```ts
+   export { functionName } from './module';
+   // or for full module re-export:
+   export * from './module';
+   ```
 4. Avoid duplicate exports and keep ordering consistent with the file.
-5. If a new module was added, ensure it has tests in `packages/<pkg>/__tests__/`.
+5. Verify the exports compile: `npm run build`.

--- a/utils/skills/verify-docs-tests/SKILL.md
+++ b/utils/skills/verify-docs-tests/SKILL.md
@@ -1,13 +1,18 @@
 ---
 name: verify-docs-tests
-description: Verify documentation and tests in fe-tools. Use when the user asks to检查文档和测试, verify docs/tests, or ensure exports and docs are aligned across utils, web-utils, node-utils, canvas-utils, or ai-utils.
+description: "Verify documentation and tests in fe-tools. Checks that exported functions have corresponding documentation and test coverage, validates JSDoc presence, and identifies missing tests. Use when the user asks to verify docs/tests, or ensure exports and docs are aligned across utils, web-utils, node-utils, canvas-utils, or ai-utils."
 ---
 # Verify Docs and Tests
 
 ## Workflow
-1. Check that exported APIs in `packages/*/src/index.ts` match documentation expectations (focus on the touched package). Use the `update-index-exports` skill if exports are missing.
-2. Verify new or changed functions have tests in `packages/*/__tests__/` for the same package.
-3. Suggest running tests:
+1. Check that exported APIs in `packages/<pkg>/src/index.ts` match documentation expectations. Compare exports against JSDoc coverage:
+   ```bash
+   # List exports to check for JSDoc
+   grep -n "^export" packages/<pkg>/src/index.ts
+   ```
+   Use the `update-index-exports` skill if exports are missing.
+2. Verify new or changed functions have tests in `packages/<pkg>/__tests__/`. A function is untested if no `describe('functionName')` or `it('...functionName...')` block exists for it.
+3. Run tests and confirm they pass:
    - `npm run test` for all packages
    - `TEST_API=<package> npm run test` for a specific package
 4. If docs output is required, suggest `npm run docs` or use the `sync-docs` skill.


### PR DESCRIPTION
Hullo @MichealWayne 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/e655fdcf-9333-4559-870f-97ddb0f1aa1d" />


| Skill | Before | After | Change |
|-------|--------|-------|--------|
| create-module-file | 0% | 94% | +94% |
| select-package | 76% | 100% | +24% |
| update-index-exports | 74% | 94% | +20% |
| add-tests | 81% | 94% | +13% |
| sync-skills | 81% | 94% | +13% |
| build-packages | 81% | 93% | +12% |
| sync-docs | 81% | 93% | +12% |
| bilingual-jsdoc | 86% | 94% | +8% |
| add-utils-function | 93% | 100% | +7% |
| fe-tools-template-recommender | 89% | 96% | +7% | 
| verify-docs-tests | 81% | 86% | +5% |
| fe-tools-frontend-resource-finder | 93% | 93% | — | 
| fe-tools-template-creator | 93% | 93% | — |

<details>
<summary>Changes made</summary>

- **create-module-file**: Fixed XML tag validation error in frontmatter description (was using `<pkg>` unquoted which failed validation); added concrete code example showing a complete module skeleton with bilingual JSDoc
- **select-package**: Expanded description with more specific actions and trigger terms ("which package", "where to add"); added example table mapping requirements to packages
- **update-index-exports**: Added concrete export syntax examples; replaced tangential test step with build verification; expanded trigger terms (barrel file, re-export, public API)
- **add-tests**: Added complete Jest test code example with describe/it/expect pattern; changed "suggest running tests" to "run tests and verify they pass" as a validation checkpoint
- **sync-skills**: Expanded description with specific tool directory names; added trigger terms (copy skills, update agent skills); added verification step
- **build-packages**: Added common error examples (missing export, type mismatch, import not found); added explicit success validation step
- **sync-docs**: Added concrete export example; added common issue patterns; added verification step for generated output
- **bilingual-jsdoc**: Added complete JSDoc code example showing the bilingual format with param/returns/example blocks; added type verification step
- **add-utils-function**: Added inline code example showing a complete function implementation with bilingual JSDoc
- **fe-tools-template-recommender**: Consolidated verbose Selection Heuristics into a compact table for improved conciseness
- **verify-docs-tests**: Added concrete grep command for checking exports; clarified what "untested" means with specific patterns to look for
- Synced all changes to `.cursor/skills/` copies

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏